### PR TITLE
nanobar.js fix - IE9 and below bar reset

### DIFF
--- a/nanobar.js
+++ b/nanobar.js
@@ -6,7 +6,20 @@ var Nanobar = (function () {
 		css = '.nanobar{float:left;width:100%;height:4px;z-index:9999;}.nanobarbar{width:0;height:100%;float:left;transition:all .3s;}',
 		head = document.head || document.getElementsByTagName( 'head' )[0];
 
+	// Check the version of IE. If IE is 10+ or not IE, it will return undefined. Otherwise it will return the IE version number.
+	var ie = (function(){
+		var undef,
+			v = 3,
+			div = document.createElement('div'),
+			all = div.getElementsByTagName('i');
 
+		while (
+			div.innerHTML = '<!--[if gt IE ' + (++v) + ']><i></i><![endif]-->',
+			all[0]
+		);
+		return v > 4 ? v : undef;
+	}());
+	
 	// Create and insert style element in head if not exists
 	addCss = function () {
 		var s = document.getElementById( 'nanobar-style' );
@@ -129,6 +142,9 @@ var Nanobar = (function () {
 
 		// create new bar at progress end
 		if (p == 100) {
+			if(ie != undefined){ //Check if IE version is less than 10. If it is, reset the height to 0.
+				 this.bars[0].style.height = 0;
+			}
 			this.init();
 		}
 	};


### PR DESCRIPTION
The progress bar does not reset on IE9 because IE9 does not support CSS transitions and thus the event handler for them is not being registered. I had to check if the client's IE version is 9 or below and if so, manually set the bar height back to 0.

You can see this bug by visiting the demo page on IE9 and spamming nanobar.go(100) several times. The bar will flood the screen instead of reset.

Note I did not apply my changes to nanobar.min.js or index.js.
