### PR TITLE
Added className and position options

### DIFF
--- a/nanobar.js
+++ b/nanobar.js
@@ -108,7 +108,7 @@ var Nanobar = (function () {
 			el.className = opts.className;
 		}
 		// set CSS position
-		el.style.position = !opts.target ? 'fixed' : opts.position || 'relative';
+		el.style.position = opts.position || !opts.target ? 'fixed' : 'relative';
 
 		// insert container
 		if (!opts.target) {


### PR DESCRIPTION
`relative` isn't always wanted when you add a Nanobar to a `target` element, so instead of adding a lot of id's and `!important` this was an easy fix.
Adding className is nice too..
