### PR TITLE
Fixed memory leak.

### DIFF
--- a/nanobar.js
+++ b/nanobar.js
@@ -53,6 +53,7 @@
 					this.el.style.height = 0;
 					setTimeout( function () {
 						self.cont.el.removeChild( self.el );
+						self.cont.bars.splice( self.cont.bars.indexOf( self ), 1 );
 					}, 300);
 				}
 			} else {


### PR DESCRIPTION
I encountered a memory leak that is caused by nanobars that reached 100% and were removed from the DOM. They are still referenced via the bars array, as a result of this cannot be processed by the garbage collection and remain as detached DOM trees.

You can easily reproduce this by clicking the nanobar.go(100) button multiple times and taking an heap snapshot afterwards - for each nanobar there is a new detached DOM tree.

I added this line of code that removes the Bar from the array when the Bar is removed from the DOM:

`self.cont.bars.splice( self.cont.bars.indexOf( self ), 1 );`
